### PR TITLE
fix: resolve Threads.js workers bundling error in production

### DIFF
--- a/packages/web/config/next/next.config.ts
+++ b/packages/web/config/next/next.config.ts
@@ -48,7 +48,7 @@ const nextConfig: NextConfig = {
     pagesBufferLength: 2,
   },
   experimental: {
-    modern: true,
+    modern: false, // this breaks Threads.js workers in production
     productionBrowserSourceMaps: PROD_ENABLE_SOURCE_MAPS,
   },
   future: {


### PR DESCRIPTION
This resolves bundling issues with Threads.js workers.

When `experimental.modern = true` in Next.js config, the application crashes in production, because worker modules canot be found.

We set `experimental.modern = false` to avoid this issue.
