### PR TITLE
chore: add cache-control header for build artefacts in _next dir

### DIFF
--- a/packages/web/config/nodemon/serve.json
+++ b/packages/web/config/nodemon/serve.json
@@ -7,7 +7,7 @@
     "babel.config.js",
     "infra/lambda-at-edge/modifyOutgoingHeaders.lambda.js",
     "package.json",
-    "src/server",
+    "tools/server",
     "tsconfig.json",
     "yarn.lock"
   ],


### PR DESCRIPTION
This modifies Lambda@Edge function to add cache-control headers to build artifacts in /_next directory. These are guaranteed to have different names on changes (due to appended hash string), so indefinite client-side caching is possible.

Also makes local server script to use the same headers.

