### PR TITLE
feat: progress indicators & better user experience

### DIFF
--- a/packages/web/src/algorithms/run.ts
+++ b/packages/web/src/algorithms/run.ts
@@ -5,7 +5,7 @@ import { readFile } from 'src/helpers/readFile'
 import { VIRUSES } from './viruses'
 import { geneMap } from './geneMap'
 
-import type { AnalysisParams, AnalysisResult } from './types'
+import type { AminoacidSubstitution, AnalysisParams, AnalysisResult, ParseResult } from './types'
 import { parseSequences } from './parseSequences'
 import { isSequenceInClade } from './isSequenceInClade'
 import { sequenceQC } from './sequenceQC'
@@ -14,15 +14,14 @@ import { analyzeSeq } from './analyzeSeq'
 import { findNucleotideRanges } from './findNucleotideRanges'
 import { getAllAminoAcidChanges } from './getAllAminoAcidChanges'
 import { GOOD_NUCLEOTIDES, N } from './nucleotides'
-import { AminoacidSubstitution } from './types'
 
-export async function parse(input: string | File) {
+export async function parse(input: string | File): Promise<ParseResult> {
   if (typeof input !== 'string') {
     // eslint-disable-next-line no-param-reassign
     input = await readFile(input)
   }
 
-  return parseSequences(input)
+  return { input, parsedSequences: parseSequences(input) }
 }
 
 export function analyze({ seqName, seq, rootSeq }: AnalysisParams): AnalysisResult {

--- a/packages/web/src/algorithms/run.ts
+++ b/packages/web/src/algorithms/run.ts
@@ -1,5 +1,7 @@
 import { pickBy } from 'lodash'
 
+import { readFile } from 'src/helpers/readFile'
+
 import { VIRUSES } from './viruses'
 import { geneMap } from './geneMap'
 
@@ -14,7 +16,12 @@ import { getAllAminoAcidChanges } from './getAllAminoAcidChanges'
 import { GOOD_NUCLEOTIDES, N } from './nucleotides'
 import { AminoacidSubstitution } from './types'
 
-export function parse(input: string) {
+export async function parse(input: string | File) {
+  if (typeof input !== 'string') {
+    // eslint-disable-next-line no-param-reassign
+    input = await readFile(input)
+  }
+
   return parseSequences(input)
 }
 

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -123,6 +123,11 @@ export interface AnalysisResult {
   diagnostics: DeepReadonly<QCResult>
 }
 
+export interface ParseResult {
+  input: string
+  parsedSequences: Record<string, string>
+}
+
 export interface AnalysisParams {
   seqName: string
   seq: string

--- a/packages/web/src/components/Main/MainPage.tsx
+++ b/packages/web/src/components/Main/MainPage.tsx
@@ -37,6 +37,7 @@ export interface MainProps {
   isDirty: boolean
   setInput(input: string): void
   setInputFile(inputFile: InputFile): void
+  setIsDirty(isDirty: boolean): void
   algorithmRunTrigger(content?: string | File): void
   exportTrigger(): void
   setShowInputBox(show: boolean): void
@@ -53,6 +54,7 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = {
   setInput,
   setInputFile: (inputFile: InputFile) => setInputFile(inputFile),
+  setIsDirty,
   algorithmRunTrigger: (content?: string | File) => algorithmRunTrigger(content),
   exportTrigger: () => exportCsvTrigger(),
   setShowInputBox,
@@ -68,6 +70,7 @@ export function MainDisconnected({
   showInputBox,
   setInput,
   setInputFile,
+  setIsDirty,
   algorithmRunTrigger,
   exportTrigger,
   setShowInputBox,

--- a/packages/web/src/components/Main/MainPage.tsx
+++ b/packages/web/src/components/Main/MainPage.tsx
@@ -17,7 +17,13 @@ import type { State } from 'src/state/reducer'
 import { selectIsDirty } from 'src/state/algorithm/algorithm.selectors'
 import type { AlgorithmParams, InputFile } from 'src/state/algorithm/algorithm.state'
 import { AnylysisStatus } from 'src/state/algorithm/algorithm.state'
-import { algorithmRunTrigger, exportCsvTrigger, setInput, setInputFile } from 'src/state/algorithm/algorithm.actions'
+import {
+  algorithmRunTrigger,
+  exportCsvTrigger,
+  setInput,
+  setInputFile,
+  setIsDirty,
+} from 'src/state/algorithm/algorithm.actions'
 import { setShowInputBox } from 'src/state/ui/ui.actions'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { Title } from 'src/components/Main/Title'
@@ -70,12 +76,14 @@ export function MainDisconnected({
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
   const hangleInputChage = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsDirty(true)
     setInput(e.target.value)
     setInputFile({ name: 'input.fasta', size: DEFAULT_INPUT.length })
   }, [setInput, setInputFile]) // prettier-ignore
   const handleRunButtonClick = useCallback(() => algorithmRunTrigger(), [algorithmRunTrigger])
 
   function loadDefaultData() {
+    setIsDirty(true)
     setShowInputBox(true)
     inputRef?.current?.focus()
     delay(setInput, 250, DEFAULT_INPUT)
@@ -83,6 +91,7 @@ export function MainDisconnected({
   }
 
   async function onUpload(file: File) {
+    setIsDirty(true)
     algorithmRunTrigger(file)
   }
 

--- a/packages/web/src/components/Main/MainPage.tsx
+++ b/packages/web/src/components/Main/MainPage.tsx
@@ -78,11 +78,15 @@ export function MainDisconnected({
 }: MainProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
-  const hangleInputChage = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setIsDirty(true)
-    setInput(e.target.value)
-    setInputFile({ name: 'input.fasta', size: DEFAULT_INPUT.length })
-  }, [setInput, setInputFile]) // prettier-ignore
+  const hangleInputChage = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsDirty(true)
+      setInput(e.target.value)
+      setInputFile({ name: 'input.fasta', size: DEFAULT_INPUT.length })
+    },
+    [setInput, setInputFile, setIsDirty],
+  )
+
   const handleRunButtonClick = useCallback(() => algorithmRunTrigger(), [algorithmRunTrigger])
 
   function loadDefaultData() {

--- a/packages/web/src/components/Main/MainPage.tsx
+++ b/packages/web/src/components/Main/MainPage.tsx
@@ -23,6 +23,7 @@ import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { Title } from 'src/components/Main/Title'
 
 import DEFAULT_INPUT from 'src/assets/data/defaultSequencesWithGaps.fasta'
+import { readFile } from 'src/helpers/readFile'
 
 export interface MainProps {
   params: AlgorithmParams
@@ -74,7 +75,8 @@ export function MainDisconnected({
     delay(setInput, 250, DEFAULT_INPUT)
   }
 
-  function onUpload(content: string, filename: string, size: number) {
+  async function onUpload(file: File) {
+    const content = await readFile(file)
     setInput(content)
     algorithmRunTrigger()
   }

--- a/packages/web/src/components/Main/MainPage.tsx
+++ b/packages/web/src/components/Main/MainPage.tsx
@@ -23,7 +23,6 @@ import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { Title } from 'src/components/Main/Title'
 
 import DEFAULT_INPUT from 'src/assets/data/defaultSequencesWithGaps.fasta'
-import { readFile } from 'src/helpers/readFile'
 
 export interface MainProps {
   params: AlgorithmParams
@@ -31,7 +30,7 @@ export interface MainProps {
   showInputBox: boolean
   isDirty: boolean
   setInput(input: string): void
-  algorithmRunTrigger(): void
+  algorithmRunTrigger(content?: string | File): void
   exportTrigger(): void
   setShowInputBox(show: boolean): void
   goToResults(): void
@@ -46,7 +45,7 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = {
   setInput,
-  algorithmRunTrigger: () => algorithmRunTrigger(),
+  algorithmRunTrigger: (content?: string | File) => algorithmRunTrigger(content),
   exportTrigger: () => exportCsvTrigger(),
   setShowInputBox,
   goToResults: () => push('/results'),
@@ -68,6 +67,7 @@ export function MainDisconnected({
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
   const hangleInputChage = useCallback((e: React.ChangeEvent<HTMLInputElement>) => { setInput(e.target.value) }, [setInput]) // prettier-ignore
+  const handleRunButtonClick = useCallback(() => algorithmRunTrigger(), [algorithmRunTrigger])
 
   function loadDefaultData() {
     setShowInputBox(true)
@@ -76,13 +76,11 @@ export function MainDisconnected({
   }
 
   async function onUpload(file: File) {
-    const content = await readFile(file)
-    setInput(content)
-    algorithmRunTrigger()
+    algorithmRunTrigger(file)
   }
 
   const runButton = (
-    <Button className="mx-auto btn-refresh" color="success" onClick={algorithmRunTrigger}>
+    <Button className="mx-auto btn-refresh" color="success" onClick={handleRunButtonClick}>
       <MdPlayArrow className="btn-icon" />
       <span>{t('Run')}</span>
     </Button>

--- a/packages/web/src/components/Main/MainPage.tsx
+++ b/packages/web/src/components/Main/MainPage.tsx
@@ -15,9 +15,9 @@ import { Uploader } from 'src/components/Main/Uploader'
 
 import type { State } from 'src/state/reducer'
 import { selectIsDirty } from 'src/state/algorithm/algorithm.selectors'
-import type { AlgorithmParams } from 'src/state/algorithm/algorithm.state'
+import type { AlgorithmParams, InputFile } from 'src/state/algorithm/algorithm.state'
 import { AnylysisStatus } from 'src/state/algorithm/algorithm.state'
-import { algorithmRunTrigger, exportCsvTrigger, setInput } from 'src/state/algorithm/algorithm.actions'
+import { algorithmRunTrigger, exportCsvTrigger, setInput, setInputFile } from 'src/state/algorithm/algorithm.actions'
 import { setShowInputBox } from 'src/state/ui/ui.actions'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { Title } from 'src/components/Main/Title'
@@ -30,6 +30,7 @@ export interface MainProps {
   showInputBox: boolean
   isDirty: boolean
   setInput(input: string): void
+  setInputFile(inputFile: InputFile): void
   algorithmRunTrigger(content?: string | File): void
   exportTrigger(): void
   setShowInputBox(show: boolean): void
@@ -45,6 +46,7 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = {
   setInput,
+  setInputFile: (inputFile: InputFile) => setInputFile(inputFile),
   algorithmRunTrigger: (content?: string | File) => algorithmRunTrigger(content),
   exportTrigger: () => exportCsvTrigger(),
   setShowInputBox,
@@ -59,6 +61,7 @@ export function MainDisconnected({
   isDirty,
   showInputBox,
   setInput,
+  setInputFile,
   algorithmRunTrigger,
   exportTrigger,
   setShowInputBox,
@@ -66,13 +69,17 @@ export function MainDisconnected({
 }: MainProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
-  const hangleInputChage = useCallback((e: React.ChangeEvent<HTMLInputElement>) => { setInput(e.target.value) }, [setInput]) // prettier-ignore
+  const hangleInputChage = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value)
+    setInputFile({ name: 'input.fasta', size: DEFAULT_INPUT.length })
+  }, [setInput, setInputFile]) // prettier-ignore
   const handleRunButtonClick = useCallback(() => algorithmRunTrigger(), [algorithmRunTrigger])
 
   function loadDefaultData() {
     setShowInputBox(true)
     inputRef?.current?.focus()
     delay(setInput, 250, DEFAULT_INPUT)
+    delay(setInputFile, 250, { name: 'input.fasta', size: DEFAULT_INPUT.length })
   }
 
   async function onUpload(file: File) {

--- a/packages/web/src/components/Main/UploadZone.tsx
+++ b/packages/web/src/components/Main/UploadZone.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
 
+import { connect } from 'react-redux'
 import { DropEvent, FileRejection, useDropzone } from 'react-dropzone'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 import FileIcon, { defaultStyles } from 'react-file-icon'
+
+import { numbro } from 'src/i18n/i18n'
+
+import { State } from 'src/state/reducer'
+import { InputFile } from 'src/state/algorithm/algorithm.state'
 
 export const FileIconFasta = () => (
   <FileIcon
@@ -29,17 +35,33 @@ export const FileIconTxt = () => (
   />
 )
 
+export function formatFileText(inputFile: InputFile) {
+  const size = numbro(inputFile.size).format({ output: 'byte', base: 'decimal', spaceSeparated: true, mantissa: 1 })
+  return `${inputFile.name} (${size})`
+}
+
 export interface UploadZoneProps {
+  inputFile?: InputFile
   onDrop<T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent): void
 }
 
-export function UploadZone({ onDrop }: UploadZoneProps) {
+const mapStateToProps = (state: State) => ({
+  inputFile: state.algorithm.inputFile,
+})
+
+const mapDispatchToProps = {}
+
+export const UploadZone = connect(mapStateToProps, mapDispatchToProps)(UploadZoneDisconnected)
+
+export function UploadZoneDisconnected({ inputFile, onDrop }: UploadZoneProps) {
   const { t } = useTranslation()
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, multiple: false })
 
   const normal = <div className="mx-auto text-center">{t('Drag & Drop a file or click to select')}</div>
 
   const active = <div className="mx-auto text-center">{t('Drop it!')}</div>
+
+  const file = inputFile && <div className="mx-auto text-center">{formatFileText(inputFile)}</div>
 
   return (
     <div {...getRootProps()}>
@@ -55,7 +77,7 @@ export function UploadZone({ onDrop }: UploadZoneProps) {
               <FileIconTxt />
             </span>
           </div>
-          <div className="mt-4">{isDragActive ? active : normal}</div>
+          <div className="mt-4">{file || (isDragActive ? active : normal)}</div>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/Main/Uploader.tsx
+++ b/packages/web/src/components/Main/Uploader.tsx
@@ -7,6 +7,7 @@ import { UncontrolledAlert } from 'reactstrap'
 import { appendDash } from 'src/helpers/appendDash'
 
 import { UploadZone } from './UploadZone'
+import { UploaderResultsStatus } from './UploaderResultsStatus'
 
 class UploadErrorTooManyFiles extends Error {
   public readonly nFiles: number
@@ -74,6 +75,7 @@ export function Uploader({ onUpload }: UploaderProps) {
     <div className="uploader-container">
       <div className="">
         <UploadZone onDrop={onDrop} />
+        <UploaderResultsStatus />
       </div>
 
       <div className="mt-3 uploader-error-list">

--- a/packages/web/src/components/Main/Uploader.tsx
+++ b/packages/web/src/components/Main/Uploader.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import { UncontrolledAlert } from 'reactstrap'
 
 import { appendDash } from 'src/helpers/appendDash'
-import { readFile, FileReaderError } from 'src/helpers/readFile'
 
 import { UploadZone } from './UploadZone'
 
@@ -24,7 +23,7 @@ class UploadErrorUnknown extends Error {
 }
 
 export interface UploaderProps {
-  onUpload(content: string, filename: string, size: number): void
+  onUpload(file: File): void
 }
 
 export function Uploader({ onUpload }: UploaderProps) {
@@ -42,8 +41,6 @@ export function Uploader({ onUpload }: UploaderProps) {
       setErrors((prevErrors) => [...prevErrors, t('Only one file is expected')])
     } else if (error instanceof UploadErrorUnknown) {
       setErrors((prevErrors) => [...prevErrors, t('Unknown error')])
-    } else if (error instanceof FileReaderError) {
-      setErrors((prevErrors) => [...prevErrors, t('Unable to read file.')])
     } else {
       throw error
     }
@@ -61,21 +58,16 @@ export function Uploader({ onUpload }: UploaderProps) {
     }
 
     const file = acceptedFiles[0]
-    const str = await readFile(file)
-    onUpload(str, file.name, file.size)
+    onUpload(file)
   }
 
   async function onDrop(acceptedFiles: File[], rejectedFiles: FileRejection[]) {
     setErrors([])
-
     try {
       await processFiles(acceptedFiles, rejectedFiles)
     } catch (error) {
       handleError(error)
-      return
     }
-
-    setErrors([])
   }
 
   return (

--- a/packages/web/src/components/Main/UploaderResultsStatus.tsx
+++ b/packages/web/src/components/Main/UploaderResultsStatus.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react'
+
+import { delay } from 'lodash'
+
+import { Progress, ProgressProps } from 'reactstrap'
+import { connect } from 'react-redux'
+import styled from 'styled-components'
+
+import type { State } from 'src/state/reducer'
+import { AnylysisStatus } from 'src/state/algorithm/algorithm.state'
+import { selectStatus } from 'src/state/algorithm/algorithm.selectors'
+
+export function delayOpacity(percent: number, setOpacity: (opacity: number | undefined) => void) {
+  let interval: number | undefined
+  if (percent === 0 || percent === 100) {
+    interval = delay(setOpacity, 1000, 0)
+  } else {
+    setOpacity(undefined)
+  }
+
+  return () => {
+    interval && clearInterval(interval)
+  }
+}
+
+export interface CustomProgressProps extends ProgressProps {
+  opacity?: number
+}
+
+export const CustomProgress = styled(Progress)`
+  position: relative;
+  top: -5px;
+  height: 5px;
+  margin: 0 5px;
+  opacity: ${(props: CustomProgressProps) => props.opacity};
+  transition: opacity 1s ease-out;
+  background-color: #adb5bd;
+`
+
+export interface SequenceStatus {
+  seqName: string
+  status: AnylysisStatus
+}
+
+export interface UploaderResultsStatusProps {
+  status: { percent: number; statusText: string }
+}
+
+const mapStateToProps = (state: State) => ({
+  status: selectStatus(state),
+})
+
+const mapDispatchToProps = {}
+
+export const UploaderResultsStatus = connect(mapStateToProps, mapDispatchToProps)(UploaderResultsStatusDisconnected)
+
+export function UploaderResultsStatusDisconnected({ status }: UploaderResultsStatusProps) {
+  const [opacity, setOpacity] = useState<number | undefined>(0)
+  useEffect(() => delayOpacity(status.percent, setOpacity), [status.percent])
+  return <CustomProgress opacity={opacity} value={status.percent} />
+}

--- a/packages/web/src/components/Results/ResultsPage.tsx
+++ b/packages/web/src/components/Results/ResultsPage.tsx
@@ -12,6 +12,7 @@ import { setInput } from 'src/state/algorithm/algorithm.actions'
 
 import { ResultsTable } from './ResultsTable'
 import { ButtonExport } from './ButtonExport'
+import { ResultsStatus } from './ResultsStatus'
 
 export interface MainProps {
   params: AlgorithmParams
@@ -45,6 +46,12 @@ export function ResultsPageDisconnected({ params, setInput, goBack }: MainProps)
                 {t('Back')}
               </Button>
             </div>
+          </Col>
+        </Row>
+
+        <Row>
+          <Col>
+            <ResultsStatus />
           </Col>
         </Row>
 

--- a/packages/web/src/components/Results/ResultsPage.tsx
+++ b/packages/web/src/components/Results/ResultsPage.tsx
@@ -8,7 +8,7 @@ import { goBack } from 'connected-next-router'
 
 import type { State } from 'src/state/reducer'
 import type { AlgorithmParams } from 'src/state/algorithm/algorithm.state'
-import { algorithmRunTrigger, setInput } from 'src/state/algorithm/algorithm.actions'
+import { setInput } from 'src/state/algorithm/algorithm.actions'
 
 import { ResultsTable } from './ResultsTable'
 import { ButtonExport } from './ButtonExport'
@@ -16,7 +16,6 @@ import { ButtonExport } from './ButtonExport'
 export interface MainProps {
   params: AlgorithmParams
   setInput(input: string): void
-  algorithmRunTrigger(_0?: unknown): void
   exportTrigger(_0?: unknown): void
   goBack(): void
 }
@@ -27,13 +26,12 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = {
   setInput,
-  algorithmRunTrigger: () => algorithmRunTrigger(),
   goBack: () => goBack(),
 }
 
 export const ResultsPage = connect(mapStateToProps, mapDispatchToProps)(ResultsPageDisconnected)
 
-export function ResultsPageDisconnected({ params, setInput, algorithmRunTrigger, goBack }: MainProps) {
+export function ResultsPageDisconnected({ params, setInput, goBack }: MainProps) {
   const { t } = useTranslation()
 
   return (

--- a/packages/web/src/components/Results/ResultsStatus.tsx
+++ b/packages/web/src/components/Results/ResultsStatus.tsx
@@ -21,7 +21,7 @@ export function selectStatus(state: State) {
   } else if (statusGlobal === AlgorithmStatus.analysisStarted) {
     const total = sequenceStatuses.length
     const done = sequenceStatuses.filter(({ status }) => status === AnylysisStatus.done).length
-    percent = parseDonePercent + (done / total) * 0.9 * 100
+    percent = parseDonePercent + (done / total) * (100 - parseDonePercent)
     const percentText = numbro(percent / 100).format({ output: 'percent', mantissa: 0 })
     statusText = i18n.t('Analysing sequences: {{done}}/{{total}} ({{percent}})', { done, total, percent: percentText })
   } else if (statusGlobal === AlgorithmStatus.done) {

--- a/packages/web/src/components/Results/ResultsStatus.tsx
+++ b/packages/web/src/components/Results/ResultsStatus.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+
+import { Progress } from 'reactstrap'
+import { connect } from 'react-redux'
+import i18n, { numbro } from 'src/i18n/i18n'
+
+import type { State } from 'src/state/reducer'
+import { AlgorithmStatus, AnylysisStatus } from 'src/state/algorithm/algorithm.state'
+
+export function selectStatus(state: State) {
+  const statusGlobal = state.algorithm.status
+  const sequenceStatuses = state.algorithm?.results.map(({ seqName, status }) => ({ seqName, status }))
+
+  const parseDonePercent = 10
+  let statusText = 'Idling'
+  let percent = 0
+
+  if (statusGlobal === AlgorithmStatus.parsingStarted) {
+    percent = parseDonePercent
+    statusText = i18n.t('Parsing...')
+  } else if (statusGlobal === AlgorithmStatus.analysisStarted) {
+    const total = sequenceStatuses.length
+    const done = sequenceStatuses.filter(({ status }) => status === AnylysisStatus.done).length
+    percent = parseDonePercent + (done / total) * 0.9 * 100
+    const percentText = numbro(percent / 100).format({ output: 'percent', mantissa: 0 })
+    statusText = i18n.t('Analysing sequences: {{done}}/{{total}} ({{percent}})', { done, total, percent: percentText })
+  } else if (statusGlobal === AlgorithmStatus.done) {
+    percent = 100
+    statusText = i18n.t('Done')
+  }
+
+  return { percent, statusText }
+}
+
+export interface SequenceStatus {
+  seqName: string
+  status: AnylysisStatus
+}
+
+export interface ResultsStatusProps {
+  status: { percent: number; statusText: string }
+}
+
+const mapStateToProps = (state: State) => ({
+  status: selectStatus(state),
+})
+
+const mapDispatchToProps = {}
+
+export const ResultsStatus = connect(mapStateToProps, mapDispatchToProps)(ResultsStatusDisconnected)
+
+export function ResultsStatusDisconnected({ status }: ResultsStatusProps) {
+  const { percent, statusText } = status
+  const color = percent === 100 ? 'transparent' : undefined
+  return (
+    <div>
+      <div className="text-right">{statusText}</div>
+      <Progress color={color} value={percent} />
+    </div>
+  )
+}

--- a/packages/web/src/components/Results/ResultsStatus.tsx
+++ b/packages/web/src/components/Results/ResultsStatus.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Progress } from 'reactstrap'
 import { connect } from 'react-redux'
-import i18n, { numbro } from 'src/i18n/i18n'
+import i18n from 'src/i18n/i18n'
 
 import type { State } from 'src/state/reducer'
 import { AlgorithmStatus, AnylysisStatus } from 'src/state/algorithm/algorithm.state'
@@ -22,8 +22,7 @@ export function selectStatus(state: State) {
     const total = sequenceStatuses.length
     const done = sequenceStatuses.filter(({ status }) => status === AnylysisStatus.done).length
     percent = parseDonePercent + (done / total) * (100 - parseDonePercent)
-    const percentText = numbro(percent / 100).format({ output: 'percent', mantissa: 0 })
-    statusText = i18n.t('Analysing sequences: {{done}}/{{total}} ({{percent}})', { done, total, percent: percentText })
+    statusText = i18n.t('Analysing sequences: {{done}}/{{total}}', { done, total })
   } else if (statusGlobal === AlgorithmStatus.done) {
     percent = 100
     statusText = i18n.t('Done')

--- a/packages/web/src/components/Results/ResultsStatus.tsx
+++ b/packages/web/src/components/Results/ResultsStatus.tsx
@@ -2,34 +2,10 @@ import React from 'react'
 
 import { Progress } from 'reactstrap'
 import { connect } from 'react-redux'
-import i18n from 'src/i18n/i18n'
 
 import type { State } from 'src/state/reducer'
-import { AlgorithmStatus, AnylysisStatus } from 'src/state/algorithm/algorithm.state'
-
-export function selectStatus(state: State) {
-  const statusGlobal = state.algorithm.status
-  const sequenceStatuses = state.algorithm.results.map(({ seqName, status }) => ({ seqName, status }))
-
-  const parseDonePercent = 10
-  let statusText = 'Idling'
-  let percent = 0
-
-  if (statusGlobal === AlgorithmStatus.parsingStarted) {
-    percent = parseDonePercent
-    statusText = i18n.t('Parsing...')
-  } else if (statusGlobal === AlgorithmStatus.analysisStarted) {
-    const total = sequenceStatuses.length
-    const done = sequenceStatuses.filter(({ status }) => status === AnylysisStatus.done).length
-    percent = parseDonePercent + (done / total) * (100 - parseDonePercent)
-    statusText = i18n.t('Analysing sequences: {{done}}/{{total}}', { done, total })
-  } else if (statusGlobal === AlgorithmStatus.done) {
-    percent = 100
-    statusText = i18n.t('Done')
-  }
-
-  return { percent, statusText }
-}
+import type { AnylysisStatus } from 'src/state/algorithm/algorithm.state'
+import { selectStatus } from 'src/state/algorithm/algorithm.selectors'
 
 export interface SequenceStatus {
   seqName: string

--- a/packages/web/src/components/Results/ResultsStatus.tsx
+++ b/packages/web/src/components/Results/ResultsStatus.tsx
@@ -9,7 +9,7 @@ import { AlgorithmStatus, AnylysisStatus } from 'src/state/algorithm/algorithm.s
 
 export function selectStatus(state: State) {
   const statusGlobal = state.algorithm.status
-  const sequenceStatuses = state.algorithm?.results.map(({ seqName, status }) => ({ seqName, status }))
+  const sequenceStatuses = state.algorithm.results.map(({ seqName, status }) => ({ seqName, status }))
 
   const parseDonePercent = 10
   let statusText = 'Idling'

--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -40,13 +40,7 @@ export function ResultDisconnected({ result }: ResultProps) {
       return (
         <tr className="results-table-row" key={seqName}>
           <ColumnName seqName={seqName} sequence={sequence} />
-          <td className="results-table-col results-table-col-clade" />
-          <td className="results-table-col results-table-col-clade" />
-          <td className="results-table-col results-table-col-clade" />
-          <td className="results-table-col results-table-col-clade" />
-          <td className="results-table-col results-table-col-clade" />
-          <td className="results-table-col results-table-col-clade" />
-          <td className="results-table-col results-table-col-mutations" />
+          <td colSpan={7} className="results-table-col results-table-col-clade" />
         </tr>
       )
     }

--- a/packages/web/src/i18n/i18n.ts
+++ b/packages/web/src/i18n/i18n.ts
@@ -9,6 +9,10 @@ import { initReactI18next } from 'react-i18next'
 import moment from 'moment'
 import numbro from 'numbro'
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import numbroLanguages from 'numbro/dist/languages.min'
+
 import { ReactComponent as GB } from 'flag-icon-css/flags/1x1/gb.svg'
 import { ReactComponent as DE } from 'flag-icon-css/flags/1x1/de.svg'
 import { ReactComponent as FR } from 'flag-icon-css/flags/1x1/fr.svg'
@@ -54,11 +58,12 @@ export interface I18NInitParams {
 }
 
 export async function i18nInit({ localeKey }: I18NInitParams) {
-  // FIXME: make it an import if possible
-  // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
-  Object.values(require('numbro/dist/languages.min.js')).forEach((l) =>
-    numbro.registerLanguage(l as numbro.NumbroLanguage),
-  )
+  const enUS = numbro.languages()['en-US']
+  const allNumbroLanguages = numbroLanguages as numbro.NumbroLanguage
+  Object.values(allNumbroLanguages).forEach((languageRaw) => {
+    // If a language object lacks some of the features, substitute these features from English
+    numbro.registerLanguage({ ...enUS, ...languageRaw })
+  })
 
   await i18n.use(initReactI18next).init({
     resources,

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -6,9 +6,9 @@ const action = actionCreatorFactory('ALGORITHM')
 
 export const setInput = action<string>('SET_INPUT')
 
-export const algorithmRunTrigger = action('RUN_TRIGGER')
+export const algorithmRunTrigger = action<string | File | undefined>('RUN_TRIGGER')
 
-export const algorithmRunAsync = action.async<void, void, void>('RUN')
+export const algorithmRunAsync = action.async<string | File | undefined, void, void>('RUN')
 
 export const parseAsync = action.async<void, string[], Error>('PARSE')
 

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -1,10 +1,13 @@
 import actionCreatorFactory from 'typescript-fsa'
 
 import type { AnalysisResult } from 'src/algorithms/types'
+import type { InputFile } from './algorithm.state'
 
 const action = actionCreatorFactory('ALGORITHM')
 
 export const setInput = action<string>('SET_INPUT')
+
+export const setInputFile = action<InputFile>('SET_INPUT_FILE')
 
 export const algorithmRunTrigger = action<string | File | undefined>('RUN_TRIGGER')
 

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -9,6 +9,8 @@ export const setInput = action<string>('SET_INPUT')
 
 export const setInputFile = action<InputFile>('SET_INPUT_FILE')
 
+export const setIsDirty = action<boolean>('SET_IS_DIRTY')
+
 export const algorithmRunTrigger = action<string | File | undefined>('RUN_TRIGGER')
 
 export const algorithmRunAsync = action.async<string | File | undefined, void, void>('RUN')

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -1,6 +1,6 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers'
 
-import { algorithmRunAsync, analyzeAsync, parseAsync, setInput, setInputFile } from './algorithm.actions'
+import { algorithmRunAsync, analyzeAsync, parseAsync, setInput, setInputFile, setIsDirty } from './algorithm.actions'
 import { agorithmDefaultState, AlgorithmStatus, AnylysisStatus } from './algorithm.state'
 
 import immerCase from '../util/fsaImmerReducer'
@@ -17,6 +17,13 @@ export const agorithmReducer = reducerWithInitialState(agorithmDefaultState)
     immerCase(setInputFile, (draft, inputFile) => {
       draft.status = AlgorithmStatus.idling
       draft.inputFile = inputFile
+    }),
+  )
+
+  .withHandling(
+    immerCase(setIsDirty, (draft, isDirty) => {
+      draft.status = AlgorithmStatus.idling
+      draft.isDirty = isDirty
     }),
   )
 

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -9,7 +9,6 @@ export const agorithmReducer = reducerWithInitialState(agorithmDefaultState)
   .withHandling(
     immerCase(setInput, (draft, input) => {
       draft.status = AlgorithmStatus.idling
-      draft.isDirty = true
       draft.params.input = input
     }),
   )
@@ -17,7 +16,6 @@ export const agorithmReducer = reducerWithInitialState(agorithmDefaultState)
   .withHandling(
     immerCase(setInputFile, (draft, inputFile) => {
       draft.status = AlgorithmStatus.idling
-      draft.isDirty = true
       draft.inputFile = inputFile
     }),
   )

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -1,6 +1,6 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers'
 
-import { algorithmRunAsync, analyzeAsync, parseAsync, setInput } from './algorithm.actions'
+import { algorithmRunAsync, analyzeAsync, parseAsync, setInput, setInputFile } from './algorithm.actions'
 import { agorithmDefaultState, AlgorithmStatus, AnylysisStatus } from './algorithm.state'
 
 import immerCase from '../util/fsaImmerReducer'
@@ -11,6 +11,14 @@ export const agorithmReducer = reducerWithInitialState(agorithmDefaultState)
       draft.status = AlgorithmStatus.idling
       draft.isDirty = true
       draft.params.input = input
+    }),
+  )
+
+  .withHandling(
+    immerCase(setInputFile, (draft, inputFile) => {
+      draft.status = AlgorithmStatus.idling
+      draft.isDirty = true
+      draft.inputFile = inputFile
     }),
   )
 

--- a/packages/web/src/state/algorithm/algorithm.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithm.sagas.ts
@@ -25,6 +25,7 @@ import {
   exportCsvTrigger,
   exportJsonTrigger,
   setInput,
+  setInputFile,
 } from './algorithm.actions'
 import { selectParams, selectResults } from './algorithm.selectors'
 
@@ -85,6 +86,13 @@ export function* workerAlgorithmRun(content?: File | string) {
   const params = (yield select(selectParams) as unknown) as ReturnType<typeof selectParams>
   const { rootSeq, input: inputState } = params
   const input = content ?? inputState
+
+  if (typeof input === 'string') {
+    yield put(setInputFile({ name: 'input.fasta', size: input.length }))
+  } else if (input instanceof File) {
+    const { name, size } = input
+    yield put(setInputFile({ name, size }))
+  }
 
   // TODO wrap into a function, handle errors
   yield put(parseAsync.started())

--- a/packages/web/src/state/algorithm/algorithm.selectors.ts
+++ b/packages/web/src/state/algorithm/algorithm.selectors.ts
@@ -1,7 +1,37 @@
+import i18n from 'src/i18n/i18n'
+
 import type { State } from 'src/state/reducer'
+import { AlgorithmStatus, AnylysisStatus } from 'src/state/algorithm/algorithm.state'
 
 export const selectParams = (state: State) => state.algorithm.params
 
 export const selectResults = (state: State) => state.algorithm.results.map((r) => r.result)
 
 export const selectIsDirty = (state: State): boolean => state.algorithm.isDirty
+
+export function selectStatus(state: State) {
+  const statusGlobal = state.algorithm.status
+  const sequenceStatuses = state.algorithm.results.map(({ seqName, status }) => ({ seqName, status }))
+
+  const parseDonePercent = 10
+  let statusText = 'Idling'
+  let percent = 0
+
+  if (statusGlobal === AlgorithmStatus.parsingStarted) {
+    statusText = i18n.t('Parsing...')
+    percent = 3
+  } else if (statusGlobal === AlgorithmStatus.parsingDone) {
+    percent = parseDonePercent
+    statusText = i18n.t('Parsing...')
+  } else if (statusGlobal === AlgorithmStatus.analysisStarted) {
+    const total = sequenceStatuses.length
+    const done = sequenceStatuses.filter(({ status }) => status === AnylysisStatus.done).length
+    percent = parseDonePercent + (done / total) * (100 - parseDonePercent)
+    statusText = i18n.t('Analysing sequences: {{done}}/{{total}}', { done, total })
+  } else if (statusGlobal === AlgorithmStatus.done) {
+    percent = 100
+    statusText = i18n.t('Done')
+  }
+
+  return { percent, statusText }
+}

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -2,6 +2,11 @@ import type { AnalysisResult } from 'src/algorithms/types'
 
 import { DEFAULT_ROOT_SEQUENCE } from 'src/algorithms/getRootSeq'
 
+export interface InputFile {
+  name: string
+  size: number
+}
+
 export interface AlgorithmParams {
   input: string
   rootSeq: string
@@ -33,6 +38,7 @@ export interface SequenceAnylysisState {
 
 export interface AlgorithmState {
   status: AlgorithmStatus
+  inputFile?: InputFile
   params: AlgorithmParams
   isDirty: boolean
   results: SequenceAnylysisState[]


### PR DESCRIPTION
This improves user experience by making interface faster, more interactive and by providing more visual feedback when different stages of the processing pipeline are running for every sequence.

 - [x] don't open text area before navigation to avoid a costly render and associated delay (already on master)
 - [x] prefetch `/` and `/results` for instant navigation (already on master)
 - [x] refactor file reading logic in order to extract it from main thread
 - [x] attempt to move file reading into the parser worker
 - [x] add progress indicator in the drag & drop box
 - [x] add global progress bar and progress messages above the table
 - [ ] ~add per-sequence progress bars and progress messages inside the table~ (cancelled because there isn't really whole lot of progress information available, and displaying "Pending" text turns out to be ugly and only slows things down)
