### PR TITLE
Changed 'back' from espalda to volver

### DIFF
--- a/packages/web/src/i18n/resources/es/common.json
+++ b/packages/web/src/i18n/resources/es/common.json
@@ -14,7 +14,7 @@
   "Alignment start: {{alnStart}}": "Inicio de alineación: {{alnStart}}",
   "Aminoacid changes ({{totalChanges}})": "Cambios de aminoácidos ({{totalChanges}})",
   "Analysing sequences: {{done}}/{{total}}": "Analizando secuencias: {{done}} / {{total}}",
-  "Back": "Espalda",
+  "Back": "Volver",
   "Biozentrum": "Biozentrum",
   "Check your data against Nextstrain's QC metrics": "Verifique sus datos con las métricas de control de calidad de Nextstrain",
   "Clade": "Clade",


### PR DESCRIPTION
Hi @ivan-aksamentov ! Based on the discussion about what 'back' refers to, I changed it to reflect the correct meaning.

Thank you again!