### PR TITLE
feat: add styled-components theme

### DIFF
--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -13,6 +13,7 @@ import type { Store } from 'redux'
 import { ConnectedRouter } from 'connected-next-router'
 import type { Persistor } from 'redux-persist'
 import type { i18n } from 'i18next'
+import { ThemeProvider } from 'styled-components'
 
 import { Provider } from 'react-redux'
 import { I18nextProvider } from 'react-i18next'
@@ -23,6 +24,8 @@ import { initialize } from 'src/initialize'
 
 import { LinkExternal } from 'src/components/Link/LinkExternal'
 import Loading from 'src/components/Loading/Loading'
+
+import { theme } from 'src/theme'
 
 import 'src/styles/global.scss'
 
@@ -55,13 +58,15 @@ export default function MyApp({ Component, pageProps, router }: AppProps) {
     <Suspense fallback={<Loading />}>
       <Provider store={store}>
         <ConnectedRouter>
-          <MDXProvider components={{ a: LinkExternal }}>
-            <PersistGate loading={null} persistor={persistor}>
-              <I18nextProvider i18n={i18n}>
-                <Component {...pageProps} />
-              </I18nextProvider>
-            </PersistGate>
-          </MDXProvider>
+          <ThemeProvider theme={theme}>
+            <MDXProvider components={{ a: LinkExternal }}>
+              <PersistGate loading={null} persistor={persistor}>
+                <I18nextProvider i18n={i18n}>
+                  <Component {...pageProps} />
+                </I18nextProvider>
+              </PersistGate>
+            </MDXProvider>
+          </ThemeProvider>
         </ConnectedRouter>
       </Provider>
     </Suspense>

--- a/packages/web/src/theme.ts
+++ b/packages/web/src/theme.ts
@@ -1,0 +1,84 @@
+import { rgba } from 'polished'
+
+export const white = '#ffffff'
+export const gray100 = '#f8f9fa'
+export const gray150 = '#eff1f3'
+export const gray200 = '#e9ecef'
+export const gray250 = '#e5e8ea'
+export const gray300 = '#dee2e6'
+export const gray400 = '#ced4da'
+export const gray500 = '#adb5bd'
+export const gray600 = '#c757d'
+export const gray700 = '#495057'
+export const gray800 = '#343a40'
+export const gray900 = '#212529'
+export const black = '#000'
+
+export const blue = '#2196f3'
+export const indigo = '#6610f2'
+export const purple = '#6f42c1'
+export const pink = '#e83e8c'
+export const red = '#e51c23'
+export const orange = '#fd7e14'
+export const yellow = '#ff9800'
+export const green = '#4caf50'
+export const teal = '#20c997'
+export const cyan = '#9c27b0'
+
+export const primary = blue
+export const secondary = gray100
+export const success = green
+export const info = cyan
+export const warning = yellow
+export const danger = red
+export const light = white
+export const dark = gray700
+
+export const basicColors = {
+  white,
+  gray100,
+  gray150,
+  gray200,
+  gray250,
+  gray300,
+  gray400,
+  gray500,
+  gray600,
+  gray700,
+  gray800,
+  gray900,
+  black,
+  blue,
+  indigo,
+  purple,
+  pink,
+  red,
+  orange,
+  yellow,
+  green,
+  teal,
+  cyan,
+}
+
+export const themeColors = {
+  primary,
+  secondary,
+  success,
+  info,
+  warning,
+  danger,
+  light,
+  dark,
+}
+
+export const shadows = {
+  medium: `2px 2px 3px 3px ${rgba(gray900, 0.25)}`,
+}
+
+export const theme = {
+  ...basicColors,
+  ...themeColors,
+  shadows,
+}
+
+export type Theme = typeof theme

--- a/packages/web/src/types/styled.d.ts
+++ b/packages/web/src/types/styled.d.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import { Theme } from 'src/theme'
+
+declare module 'styled-components' {
+  export declare interface DefaultTheme extends Theme {}
+}


### PR DESCRIPTION
This passes a theme object though React context, such that styled components can use theme properties attached as props.
