### PR TITLE
fix: show sequences being analyzed again

### DIFF
--- a/packages/web/src/filtering/filterByQCIssues.ts
+++ b/packages/web/src/filtering/filterByQCIssues.ts
@@ -1,10 +1,20 @@
 import type { SequenceAnylysisState } from 'src/state/algorithm/algorithm.state'
 
-export function filterByQCIssues(hasNoQcIssuesFilter: boolean, hasQcIssuesFilter: boolean, hasErrorsFilter: boolean) {
+export interface FilterByQCIssuesParams {
+  hasNoQcIssuesFilter: boolean
+  hasQcIssuesFilter: boolean
+  hasErrorsFilter: boolean
+}
+
+export function filterByQCIssues({ hasNoQcIssuesFilter, hasQcIssuesFilter, hasErrorsFilter }: FilterByQCIssuesParams) {
   return ({ result, errors }: SequenceAnylysisState) => {
     const hasErrors = errors.length > 0
-    const hasIssues = hasErrors || (result && result.diagnostics.flags.length > 0)
-    const hasNoIssues = result && result.diagnostics.flags.length === 0
+
+    const hasIssues = result && result.diagnostics.flags.length > 0
+
+    // // Sequences still being processed (!result) are assumed to have no issues until the results come and prove otherwise
+    const hasNoIssues = (!hasErrors && !result) || (result && result.diagnostics.flags.length === 0)
+
     return (hasNoQcIssuesFilter && hasNoIssues) || (hasQcIssuesFilter && hasIssues) || (hasErrorsFilter && hasErrors)
   }
 }

--- a/packages/web/src/filtering/runFilters.ts
+++ b/packages/web/src/filtering/runFilters.ts
@@ -37,7 +37,7 @@ export function runFilters(state: AlgorithmState) {
     filtered = filtered.filter(filterByClades(cladesFilter))
   }
 
-  filtered = filtered.filter(filterByQCIssues(hasNoQcIssuesFilter, hasQcIssuesFilter, hasErrorsFilter))
+  filtered = filtered.filter(filterByQCIssues({ hasNoQcIssuesFilter, hasQcIssuesFilter, hasErrorsFilter }))
 
   return filtered as DeepWritable<typeof filtered>
 }


### PR DESCRIPTION
Due to a bug in filtering, the incomplete (not yet fully analyzed) sequences were not being shown in results table. This PR fixes that.