### PR TITLE
Fix/short alignments

### DIFF
--- a/packages/web/src/algorithms/isSequenceInClade.ts
+++ b/packages/web/src/algorithms/isSequenceInClade.ts
@@ -12,6 +12,8 @@ export function isSequenceInClade(
   return cladeAlleles.every(({ pos, nuc }) => {
     // clade definition by nextstrain use one-based indices, hence substract 1 to retrieve allele in reference and mutations object
     const posZeroBased = pos - 1
+    // if the position isn't part of the aligned region, we can't call the clade
+    // the function will then conservatively return false
     if (posZeroBased < alignmentStart || posZeroBased >= alignmentEnd) {
       return false
     }

--- a/packages/web/src/algorithms/isSequenceInClade.ts
+++ b/packages/web/src/algorithms/isSequenceInClade.ts
@@ -5,11 +5,16 @@ import type { NucleotideLocation, NucleotideSubstitution } from './types'
 export function isSequenceInClade(
   cladeAlleles: DeepReadonly<NucleotideLocation[]>,
   mutations: NucleotideSubstitution[],
+  alignmentStart: number,
+  alignmentEnd: number,
   reference: string,
 ) {
   return cladeAlleles.every(({ pos, nuc }) => {
     // clade definition by nextstrain use one-based indices, hence substract 1 to retrieve allele in reference and mutations object
     const posZeroBased = pos - 1
+    if (posZeroBased < alignmentStart || posZeroBased >= alignmentEnd) {
+      return false
+    }
     const state = mutations.find(({ pos }) => pos === posZeroBased)?.queryNuc ?? reference[posZeroBased]
     return state === nuc
   })

--- a/packages/web/src/algorithms/run.ts
+++ b/packages/web/src/algorithms/run.ts
@@ -27,7 +27,7 @@ export async function parse(input: string | File): Promise<ParseResult> {
 export function analyze({ seqName, seq, rootSeq }: AnalysisParams): AnalysisResult {
   const virus = VIRUSES['SARS-CoV-2']
 
-  if (seq.length < virus.QCParams.minimalLength){
+  if (seq.length < virus.QCParams.minimalLength) {
     throw new Error(`sequence is too short for reliable alignment and QC analysis`)
   }
 

--- a/packages/web/src/algorithms/run.ts
+++ b/packages/web/src/algorithms/run.ts
@@ -37,7 +37,9 @@ export function analyze({ seqName, seq, rootSeq }: AnalysisParams): AnalysisResu
   const totalGaps = deletions.reduce((total, { length }) => total + length, 0)
   const totalInsertions = insertions.reduce((total, { ins }) => total + ins.length, 0)
 
-  const clades = pickBy(virus.clades, (clade) => isSequenceInClade(clade, nucSubstitutions, rootSeq))
+  const clades = pickBy(virus.clades, (clade) =>
+    isSequenceInClade(clade, nucSubstitutions, alignmentStart, alignmentEnd, rootSeq),
+  )
 
   const missing = findNucleotideRanges(alignedQuery, N)
   const totalMissing = missing.reduce((total, { begin, end }) => total + end - begin, 0)

--- a/packages/web/src/algorithms/run.ts
+++ b/packages/web/src/algorithms/run.ts
@@ -27,6 +27,10 @@ export async function parse(input: string | File): Promise<ParseResult> {
 export function analyze({ seqName, seq, rootSeq }: AnalysisParams): AnalysisResult {
   const virus = VIRUSES['SARS-CoV-2']
 
+  if (seq.length < virus.QCParams.minimalLength){
+    throw new Error(`sequence is too short for reliable alignment and QC analysis`)
+  }
+
   const { alignmentScore, query, ref } = alignPairwise(seq, rootSeq)
 
   const alignedQuery = query.join('')

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -77,6 +77,7 @@ export interface QCParameters {
   divergenceThreshold: number
   mixedSitesThreshold: number
   missingDataThreshold: number
+  minimalLength: number
 }
 
 export interface Virus {

--- a/packages/web/src/algorithms/viruses.ts
+++ b/packages/web/src/algorithms/viruses.ts
@@ -10,6 +10,7 @@ export const VIRUSES: Record<string, Virus> = {
       divergenceThreshold: 20, // number of mutations to trigger divergence warning
       mixedSitesThreshold: 10, // number of non-ACGTN sites to trigger warning
       missingDataThreshold: 1000, // number of sites as N to trigger warning
+      minimalLength: 100, // minimal length to attempt alignment
     },
     clades: {
       '19A': [

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnSeqView.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnSeqView.mdx
@@ -11,7 +11,7 @@ Line markers on sequence views represent mutations colored by the resulting nucl
 
 <HelpTipsColumnSeqViewLegend />
 
-
+Unsequenced regions at the 5' and 3' end are indicated as light gray shading.
 For a mapping between positions in the sequence, genes and clade-defining mutations, see Genome Annotation view below the table.
 Note that sometimes mutations are so close to each other that they overlap.
 

--- a/packages/web/src/components/SequenceView/SequenceMarkerMissingEnds.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMissingEnds.tsx
@@ -1,0 +1,51 @@
+import React, { SVGProps, useState } from 'react'
+
+import { useTranslation } from 'react-i18next'
+import { BASE_MIN_WIDTH_PX } from 'src/constants'
+
+import type { NucleotideDeletion } from 'src/algorithms/types'
+import { Tooltip } from 'src/components/Results/Tooltip'
+import { formatRange } from 'src/helpers/formatRange'
+import { getSafeId } from 'src/helpers/getSafeId'
+
+const missingEndColor = '#BBBBBB'
+
+export interface MissingEndsViewProps extends SVGProps<SVGRectElement> {
+  seqName: string
+  deletion: NucleotideDeletion
+  pixelsPerBase: number
+}
+
+export function SequenceMarkerMissingEnds({ seqName, deletion, pixelsPerBase, ...rest }: MissingEndsViewProps) {
+  const { t } = useTranslation()
+  const [showTooltip, setShowTooltip] = useState(false)
+
+  const { start: begin, length } = deletion
+  const end = begin + length
+
+  const id = getSafeId('missing-end-marker', { seqName, ...deletion })
+
+  const x = begin * pixelsPerBase
+  let width = (end - begin) * pixelsPerBase
+  width = Math.max(width, BASE_MIN_WIDTH_PX)
+
+  const rangeStr = formatRange(begin, end)
+
+  return (
+    <rect
+      id={id}
+      fill={missingEndColor}
+      x={x}
+      y={-10}
+      width={width}
+      height="30"
+      {...rest}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <Tooltip target={id} isOpen={showTooltip}>
+        {t('Not sequenced: {{range}}', { range: rangeStr })}
+      </Tooltip>
+    </rect>
+  )
+}

--- a/packages/web/src/components/SequenceView/SequenceView.tsx
+++ b/packages/web/src/components/SequenceView/SequenceView.tsx
@@ -8,6 +8,7 @@ import type { AnalysisResult } from 'src/algorithms/types'
 import { SequenceMarkerGap } from './SequenceMarkerGap'
 import { SequenceMarkerMissing } from './SequenceMarkerMissing'
 import { SequenceMarkerMutation } from './SequenceMarkerMutation'
+import { SequenceMarkerMissingEnds } from './SequenceMarkerMissingEnds'
 
 export const GENOME_SIZE = 30000 as const // TODO: deduce from sequences?
 
@@ -38,7 +39,7 @@ export interface SequenceViewProps extends ReactResizeDetectorDimensions {
 export const SequenceView = withResizeDetector(SequenceViewUnsized)
 
 export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
-  const { seqName, substitutions, missing, deletions } = sequence
+  const { seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd } = sequence
 
   if (!width) {
     return (
@@ -72,6 +73,20 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     )
   })
 
+  const missingEndViews = [
+    { start: 0, length: alignmentStart },
+    { start: alignmentEnd, length: GENOME_SIZE - alignmentEnd },
+  ].map((missingEnd) => {
+    return (
+      <SequenceMarkerMissingEnds
+        key={missingEnd.start}
+        seqName={seqName}
+        deletion={missingEnd}
+        pixelsPerBase={pixelsPerBase}
+      />
+    )
+  })
+
   const deletionViews = deletions.map((deletion) => {
     return (
       <SequenceMarkerGap key={deletion.start} seqName={seqName} deletion={deletion} pixelsPerBase={pixelsPerBase} />
@@ -82,6 +97,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     <SequenceViewWrapper>
       <SequenceViewSVG viewBox={`0 0 ${width} 10`}>
         <rect fill="transparent" x={0} y={-10} width={GENOME_SIZE} height="30" />
+        {missingEndViews}
         {mutationViews}
         {missingViews}
         {deletionViews}


### PR DESCRIPTION
This PR implements improvements to how we handle genomic fragments, i.e. sequences that are only a fraction of the genome. The app currently treats short sequences as if there are basically the reference genome, as pointed out by @george-githinji in Issue #135 

this proposed changes 
 * don't attempt to align if sequences are short than 100 bases
 * don't call a clade if some of the clade defining mutations are not covered by the alignment
 * indicated unsequenced regions in the sequence view. 

The remaining question is whether the QC thresholds should scale with the length of aligned fragment. For missing data and divergence this seems plausible. 

