### PR TITLE
feat: add ability to disable filters temporarily

### DIFF
--- a/packages/web/src/components/Tree/FilterBadges.tsx
+++ b/packages/web/src/components/Tree/FilterBadges.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 import { State } from 'src/state/reducer'
 import { FilterBadge } from 'src/components/Tree/FilterBadge'
+import { uniq, get } from 'lodash'
 
 export const FilterBadgeContainer = styled.ul`
   display: flex;
@@ -40,6 +41,22 @@ const mapDispatchToProps = {}
 export const FilterBadges = connect(mapStateToProps, mapDispatchToProps)(FilterBadgesDisconnected)
 
 export function FilterBadgesDisconnected({ filters }: FilterBadgesProps) {
+  const [badgesDisabled, setBadgesDisabled] = useState<Record<string, string[]>>({})
+
+  const setBadgeDisabled = useCallback((trait: string, value: string) => {
+    setBadgesDisabled((badgesDisabled) => ({
+      ...badgesDisabled,
+      [trait]: uniq([...(get(badgesDisabled, trait) ?? []), value]),
+    }))
+  }, [])
+
+  const setBadgeEnabled = useCallback((trait: string, value: string) => {
+    setBadgesDisabled((badgesDisabled) => ({
+      ...badgesDisabled,
+      [trait]: get(badgesDisabled, trait)?.filter((val) => val !== value),
+    }))
+  }, [])
+
   const filterBadges = useMemo(() => {
     if (!filters) {
       return []
@@ -47,10 +64,44 @@ export function FilterBadgesDisconnected({ filters }: FilterBadgesProps) {
 
     return Object.entries(filters).reduce(
       (result, [trait, filters]) =>
-        result.concat(filters.map((filter) => <FilterBadge key={`${trait}:${filter}`} trait={trait} value={filter} />)),
+        result.concat(
+          filters.map((filter) => (
+            <FilterBadge
+              key={`${trait}:${filter}`}
+              trait={trait}
+              value={filter}
+              setDisabled={setBadgeDisabled}
+              setEnabled={setBadgeEnabled}
+            />
+          )),
+        ),
       [] as React.ReactNode[],
     )
-  }, [filters])
+  }, [filters, setBadgeDisabled, setBadgeEnabled])
 
-  return <FilterBadgeContainer>{filterBadges}</FilterBadgeContainer>
+  const filtersBadgesDisabled = useMemo(() => {
+    return Object.entries(badgesDisabled).reduce(
+      (result, [trait, filters]) =>
+        result.concat(
+          filters.map((filter) => (
+            <FilterBadge
+              key={`${trait}:${filter} (disabled)`}
+              trait={trait}
+              value={filter}
+              setDisabled={setBadgeDisabled}
+              setEnabled={setBadgeEnabled}
+              disabled
+            />
+          )),
+        ),
+      [] as React.ReactNode[],
+    )
+  }, [badgesDisabled, setBadgeDisabled, setBadgeEnabled])
+
+  return (
+    <>
+      <FilterBadgeContainer>{filterBadges}</FilterBadgeContainer>
+      <FilterBadgeContainer>{filtersBadgesDisabled}</FilterBadgeContainer>
+    </>
+  )
 }


### PR DESCRIPTION
Clicking on a filter badge temporarily disables the filter. Clicking again re-enables it.

The current implementation is somewhat naive and not robust in some of the cases cases. Upstream changes in Auspice are required for proper implementation to be possible.
