### PR TITLE
chore: make redux devtools faster

### DIFF
--- a/packages/web/src/components/Results/ButtonTree.tsx
+++ b/packages/web/src/components/Results/ButtonTree.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useCallback } from 'react'
 
 import styled from 'styled-components'
 import { connect } from 'react-redux'
@@ -44,9 +44,10 @@ export interface ButtonTreeProps extends ButtonProps {
 
 export function ButtonTreeDisconnected({ showTree, hasResults }: ButtonTreeProps) {
   const { t } = useTranslation()
+  const showTreeLocal = useCallback(() => showTree(), [showTree])
 
   return (
-    <ButtonStyled color="success" onClick={showTree} disabled={!hasResults}>
+    <ButtonStyled color="success" onClick={showTreeLocal} disabled={!hasResults}>
       <IconContainer>
         <TreeIcon />
       </IconContainer>

--- a/packages/web/src/state/reducer.ts
+++ b/packages/web/src/state/reducer.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux'
-import { persistReducer } from 'redux-persist'
+import { persistReducer, PersistedState } from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
 import { routerReducer } from 'connected-next-router'
 import { RouterState } from 'connected-next-router/types'
@@ -30,7 +30,7 @@ import { auspiceGeneralReducer, auspiceQueryReducer } from './auspice/auspice.re
 
 export interface State extends AuspiceState {
   algorithm: AlgorithmState
-  settings: SettingsState
+  settings: SettingsState & PersistedState
   router: RouterState
   ui: UiState
 }

--- a/packages/web/src/state/util/withReduxDevTools.ts
+++ b/packages/web/src/state/util/withReduxDevTools.ts
@@ -41,13 +41,13 @@ export function withReduxDevTools<StoreEnhancerIn, StoreEnhancerOut>(
     // @ts-ignore
     actionSanitizer(action: Action<unknown>) {
       // @ts-ignore
-      if (action.type === 'CLEAN_START' && action?.tree) {
+      if (action.type === 'CLEAN_START') {
         return {
           ...action,
           // @ts-ignore
-          tree: sanitizeTree(action?.tree),
+          tree: sanitizeTree(action.tree),
           // @ts-ignore
-          entropy: sanitizeEntropy(action?.controls),
+          entropy: sanitizeEntropy(action.controls),
         }
       }
       return action
@@ -61,8 +61,8 @@ export function withReduxDevTools<StoreEnhancerIn, StoreEnhancerOut>(
           results: sanitizeResults(state.algorithm.results),
           resultsFiltered: sanitizeResults(state.algorithm.results),
         },
-        tree: sanitizeTree(state?.tree),
-        entropy: sanitizeEntropy(state?.controls),
+        tree: sanitizeTree(state.tree),
+        entropy: sanitizeEntropy(state.controls),
       }
     },
 

--- a/packages/web/src/state/util/withReduxDevTools.ts
+++ b/packages/web/src/state/util/withReduxDevTools.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { composeWithDevTools } from 'redux-devtools-extension'
+import type { Action } from 'typescript-fsa'
+
+import type { State } from 'src/state/reducer'
+import type { SequenceAnylysisState } from 'src/state/algorithm/algorithm.state'
+import { AuspiceEntropyState, AuspiceTreeState } from 'auspice'
+import { StrictOmit } from 'ts-essentials'
+
+const TOO_BIG = '<<TOO_BIG>>' as const
+
+function sanitizeResults(results: SequenceAnylysisState[] = []) {
+  return results && results.length > 20 ? TOO_BIG : results
+}
+
+export interface AuspiceTreeStateLite
+  extends StrictOmit<AuspiceTreeState, 'nodes' | 'visibility' | 'nodeColors' | 'branchThickness'> {
+  nodes: string
+  visibility: string
+  nodeColors: string
+  branchThickness: string
+}
+
+function sanitizeTree(tree: AuspiceTreeState = {}): AuspiceTreeStateLite {
+  return { ...tree, nodes: TOO_BIG, visibility: TOO_BIG, nodeColors: TOO_BIG, branchThickness: TOO_BIG }
+}
+
+function sanitizeEntropy(entropy: AuspiceEntropyState = {}) {
+  return { ...entropy, bars: TOO_BIG }
+}
+
+export function withReduxDevTools<StoreEnhancerIn, StoreEnhancerOut>(
+  enhancer: StoreEnhancerIn,
+): StoreEnhancerIn | StoreEnhancerOut {
+  if (!(process.env.ENABLE_REDUX_DEV_TOOLS === 'true' && composeWithDevTools)) {
+    return enhancer
+  }
+
+  // @ts-ignore
+  const compose = composeWithDevTools({
+    // @ts-ignore
+    actionSanitizer(action: Action<unknown>) {
+      // @ts-ignore
+      if (action.type === 'CLEAN_START' && action?.tree) {
+        return {
+          ...action,
+          // @ts-ignore
+          tree: sanitizeTree(action?.tree),
+          // @ts-ignore
+          entropy: sanitizeEntropy(action?.controls),
+        }
+      }
+      return action
+    },
+
+    stateSanitizer(state: State) {
+      return {
+        ...state,
+        algorithm: {
+          ...state.algorithm,
+          results: sanitizeResults(state.algorithm.results),
+          resultsFiltered: sanitizeResults(state.algorithm.results),
+        },
+        tree: sanitizeTree(state?.tree),
+        entropy: sanitizeEntropy(state?.controls),
+      }
+    },
+
+    trace: true,
+    traceLimit: 25,
+    actionsBlacklist: '@@INIT',
+  })
+
+  // @ts-ignore
+  return compose(enhancer)
+}

--- a/packages/web/src/types/auspice/index.d.ts
+++ b/packages/web/src/types/auspice/index.d.ts
@@ -3,123 +3,131 @@
 declare module 'auspice' {
   export declare type AuspiceQuery = Record<string, unknown>
 
-  export declare type AuspiceState = {
-    metadata?: AuspiceMetadata
-    tree?: {
-      name?: string | boolean
-      loaded?: boolean
-      nodes?: AuspiceTreeNode[]
-      visibility?: number[]
-      visibilityVersion?: number
-      nodeColors?: string[]
-      nodeColorsVersion?: number
-      tipRadii?: any
-      tipRadiiVersion?: number
-      branchThickness?: number[]
-      branchThicknessVersion?: number
-      vaccines?: []
-      version?: number
-      idxOfInViewRootNode?: number
-      visibleStateCounts?: any
-      totalStateCounts?: Record<string, Map<string, number>>
-      availableBranchLabels?: string[]
-      selectedStrain?: any
-      selectedClade?: any
-      debug?: any
-      stateCountAttrs?: any
-    }
-    frequencies?: {
-      loaded?: boolean
-      data?: any
-      pivots?: any
-      matrix?: any
-      projection_pivot?: any
-      version?: any
-    }
-    controls?: {
-      defaults?: {
-        distanceMeasure?: string
-        layout?: string
-        geoResolution?: string
-        filters?: Record<string, string[]>
-        colorBy?: string
-        selectedBranchLabel?: string
-        showTransmissionLines?: boolean
-        panels?: Record<string, any>
-      }
-      available?: any
-      canTogglePanelLayout?: boolean
-      selectedBranch?: any
-      selectedNode?: any
-      region?: any
-      search?: any
-      strain?: any
-      geneLength?: Record<string, number>
-      mutType?: string
-      temporalConfidence?: { exists?: boolean; display?: boolean; on?: boolean }
-      layout?: string
+  export interface AuspiceTreeState {
+    name?: string | boolean
+    loaded?: boolean
+    nodes?: AuspiceTreeNode[]
+    visibility?: number[]
+    visibilityVersion?: number
+    nodeColors?: string[]
+    nodeColorsVersion?: number
+    tipRadii?: any
+    tipRadiiVersion?: number
+    branchThickness?: number[]
+    branchThicknessVersion?: number
+    vaccines?: []
+    version?: number
+    idxOfInViewRootNode?: number
+    visibleStateCounts?: any
+    totalStateCounts?: Record<string, Map<string, number>>
+    availableBranchLabels?: string[]
+    selectedStrain?: any
+    selectedClade?: any
+    debug?: any
+    stateCountAttrs?: any
+  }
+
+  export interface AuspiceFrequenciesState {
+    loaded?: boolean
+    data?: any
+    pivots?: any
+    matrix?: any
+    projection_pivot?: any
+    version?: any
+  }
+
+  export interface AuspiceControlsState {
+    defaults?: {
       distanceMeasure?: string
-      dateMin?: Date
-      dateMinNumeric?: number
-      dateMax?: string
-      dateMaxNumeric?: number
-      absoluteDateMin?: Date
-      absoluteDateMinNumeric?: number
-      absoluteDateMax?: string
-      absoluteDateMaxNumeric?: number
-      colorBy?: string
-      colorByConfidence?: boolean
-      colorScale?: {
-        scale?: Record<string, any>
-        continuous?: boolean
-        colorBy?: string
-        version?: number
-        legendValues?: Record<string, any>
-        legendBounds?: any
-        genotype?: any
-      }
-      selectedBranchLabel?: string
-      analysisSlider?: boolean
+      layout?: string
       geoResolution?: string
       filters?: Record<string, string[]>
-      showDownload?: boolean
-      quickdraw?: boolean
-      mapAnimationDurationInMilliseconds?: number
-      mapAnimationStartDate?: Date
-      mapAnimationCumulative?: boolean
-      mapAnimationShouldLoop?: boolean
-      animationPlayPauseButton?: string
-      panelsAvailable?: string[]
-      panelsToDisplay?: string[]
-      panelLayout?: string
-      showTreeToo?: boolean
-      showTangle?: boolean
-      zoomMin?: any
-      zoomMax?: any
-      branchLengthsToDisplay?: string
-      sidebarOpen?: boolean
-      treeLegendOpen?: any
-      mapLegendOpen?: any
-      showOnlyPanels?: boolean
+      colorBy?: string
+      selectedBranchLabel?: string
       showTransmissionLines?: boolean
-      normalizeFrequencies?: boolean
-      coloringsPresentOnTree?: any
-      coloringsPresentOnTreeWithConfidence?: any
-      absoluteZoomMin?: number
-      absoluteZoomMax?: number
+      panels?: Record<string, any>
     }
-    entropy?: {
-      showCounts?: boolean
-      loaded?: boolean
-      annotations?: any[]
-      lengthSequence?: number
-      geneMap?: Record<string, any>
-      bars?: any[]
-      maxYVal?: number
-      zoomMax?: any
-      zoomMin?: any
-      zoomCoordinates?: [any, any]
+    available?: any
+    canTogglePanelLayout?: boolean
+    selectedBranch?: any
+    selectedNode?: any
+    region?: any
+    search?: any
+    strain?: any
+    geneLength?: Record<string, number>
+    mutType?: string
+    temporalConfidence?: { exists?: boolean; display?: boolean; on?: boolean }
+    layout?: string
+    distanceMeasure?: string
+    dateMin?: Date
+    dateMinNumeric?: number
+    dateMax?: string
+    dateMaxNumeric?: number
+    absoluteDateMin?: Date
+    absoluteDateMinNumeric?: number
+    absoluteDateMax?: string
+    absoluteDateMaxNumeric?: number
+    colorBy?: string
+    colorByConfidence?: boolean
+    colorScale?: {
+      scale?: Record<string, any>
+      continuous?: boolean
+      colorBy?: string
+      version?: number
+      legendValues?: Record<string, any>
+      legendBounds?: any
+      genotype?: any
     }
+    selectedBranchLabel?: string
+    analysisSlider?: boolean
+    geoResolution?: string
+    filters?: Record<string, string[]>
+    showDownload?: boolean
+    quickdraw?: boolean
+    mapAnimationDurationInMilliseconds?: number
+    mapAnimationStartDate?: Date
+    mapAnimationCumulative?: boolean
+    mapAnimationShouldLoop?: boolean
+    animationPlayPauseButton?: string
+    panelsAvailable?: string[]
+    panelsToDisplay?: string[]
+    panelLayout?: string
+    showTreeToo?: boolean
+    showTangle?: boolean
+    zoomMin?: any
+    zoomMax?: any
+    branchLengthsToDisplay?: string
+    sidebarOpen?: boolean
+    treeLegendOpen?: any
+    mapLegendOpen?: any
+    showOnlyPanels?: boolean
+    showTransmissionLines?: boolean
+    normalizeFrequencies?: boolean
+    coloringsPresentOnTree?: any
+    coloringsPresentOnTreeWithConfidence?: any
+    absoluteZoomMin?: number
+    absoluteZoomMax?: number
+  }
+
+  export interface AuspiceEntropyState {
+    showCounts?: boolean
+    loaded?: boolean
+    annotations?: any[]
+    lengthSequence?: number
+    geneMap?: Record<string, any>
+    bars?: any[]
+    maxYVal?: number
+    zoomMax?: any
+    zoomMin?: any
+    zoomCoordinates?: [any, any]
+  }
+
+  export declare type AuspiceState = {
+    metadata?: AuspiceMetadata
+    tree?: AuspiceTreeState
+    frequencies?: AuspiceFrequenciesState
+    controls?: AuspiceControlsState
+    entropy?: AuspiceEntropyState
     browserDimensions?: { browserDimensions?: { width?: number; height?: number; docHeight?: number } }
     notifications?: { stack?: any[]; counter?: number }
     narrative?: {
@@ -130,27 +138,7 @@ declare module 'auspice' {
       display?: boolean
       title?: any
     }
-    treeToo?: {
-      loaded?: boolean
-      nodes?: any
-      name?: any
-      visibility?: any
-      visibilityVersion?: any
-      nodeColors?: any
-      nodeColorsVersion?: any
-      tipRadii?: any
-      tipRadiiVersion?: any
-      branchThickness?: any
-      branchThicknessVersion?: any
-      vaccines?: boolean
-      version?: any
-      idxOfInViewRootNode?: any
-      visibleStateCounts?: any
-      totalStateCounts?: any
-      availableBranchLabels?: any[]
-      selectedStrain?: any
-      selectedClade?: any
-    }
+    treeToo?: AuspiceTreeState
     general?: { language?: string }
     query?: any
   }

--- a/packages/web/src/types/auspice/src/reducers/controls.d.ts
+++ b/packages/web/src/types/auspice/src/reducers/controls.d.ts
@@ -1,5 +1,6 @@
 declare module 'auspice/src/reducers/controls' {
-  export declare type ControlsState = Record<string, unknown>
-  declare function controls(state?: ControlsState): ControlsState | undefined
+  import { AuspiceControlsState } from 'auspice'
+
+  declare function controls(state?: AuspiceControlsState): AuspiceControlsState | undefined
   export default controls
 }

--- a/packages/web/src/types/auspice/src/reducers/entropy.d.ts
+++ b/packages/web/src/types/auspice/src/reducers/entropy.d.ts
@@ -1,5 +1,6 @@
 declare module 'auspice/src/reducers/entropy' {
-  export declare type EntropyState = Record<string, unknown>
-  declare function entropy(state?: EntropyState): EntropyState | undefined
+  import { AuspiceEntropyState } from 'auspice'
+
+  declare function entropy(state?: AuspiceEntropyState): AuspiceEntropyState | undefined
   export default entropy
 }

--- a/packages/web/src/types/auspice/src/reducers/frequencies.d.ts
+++ b/packages/web/src/types/auspice/src/reducers/frequencies.d.ts
@@ -1,5 +1,6 @@
 declare module 'auspice/src/reducers/frequencies' {
-  export declare type FrequenciesState = Record<string, unknown>
-  declare function frequencies(State?: FrequenciesState): FrequenciesState | undefined
+  import { AuspiceFrequenciesState } from 'auspice'
+
+  declare function frequencies(State?: AuspiceFrequenciesState): AuspiceFrequenciesState | undefined
   export default frequencies
 }

--- a/packages/web/src/types/auspice/src/reducers/tree.d.ts
+++ b/packages/web/src/types/auspice/src/reducers/tree.d.ts
@@ -1,5 +1,6 @@
 declare module 'auspice/src/reducers/tree' {
-  export declare type TreeState = Record<string, unknown>
-  declare function tree(state?: TreeState): TreeState | undefined
+  import { AuspiceTreeState } from 'auspice'
+
+  declare function tree(state?: TreeState): AuspiceTreeState | undefined
   export default tree
 }

--- a/packages/web/src/types/auspice/src/reducers/treeToo.d.ts
+++ b/packages/web/src/types/auspice/src/reducers/treeToo.d.ts
@@ -1,5 +1,6 @@
 declare module 'auspice/src/reducers/treeToo' {
-  export declare type TreeTooState = Record<string, unknown>
-  declare function treeToo(state?: TreeTooState): TreeTooState | undefined
+  import { AuspiceTreeState } from 'auspice'
+
+  declare function treeToo(state?: AuspiceTreeState): AuspiceTreeState | undefined
   export default treeToo
 }


### PR DESCRIPTION
Contributes to #139 

This:
 - filters parts of the state and actions from the serialization
 - adjusts types so that filtering is somewhat typesafe (it is not perfect still, due to strange types in redux devtools package)
 - avoids unnecessary payload on one of the click actions

